### PR TITLE
[ 진욱 ] Article 타입 수정

### DIFF
--- a/src/types/apis/articles/CreateArticle.ts
+++ b/src/types/apis/articles/CreateArticle.ts
@@ -1,5 +1,7 @@
+import { ArticleContent } from "@type/models/Article";
+
 export interface CreateArticleRequestBody {
-  title: string;
+  title: ArticleContent;
   image?: BinaryData | null;
   channelId: string;
 }

--- a/src/types/apis/articles/UpdateArticle.ts
+++ b/src/types/apis/articles/UpdateArticle.ts
@@ -1,6 +1,8 @@
+import { ArticleContent } from "@type/models/Article";
+
 export interface UpdateArticleRequestBody {
   postId: string;
-  title: string;
+  title: ArticleContent;
   image?: BinaryData | null;
   imageToDeletePublicId?: string;
   channelId: string;

--- a/src/types/models/Article.ts
+++ b/src/types/models/Article.ts
@@ -2,13 +2,20 @@ import { Channel } from "./Channel";
 import { Like } from "./Like";
 import { User } from "./User";
 
+export interface ArticleContent {
+  title: string;
+  content: string;
+  isQuestion: boolean;
+  tags: string[];
+}
+
 export interface Article {
   likes: Like[];
   comments: Comment[];
   _id: string;
   image?: string;
   imagePublicId?: string;
-  title: string;
+  title: ArticleContent;
   channel: Channel;
   author: User;
   createdAt: string;


### PR DESCRIPTION
## 📌 이슈 번호
close #40 

## 🚀 구현 내용
ArticleContent 타입 선언 후 관련된 타입들에 적용했습니다.
```ts
export interface ArticleContent {
  title: string;
  content: string;
  isQuestion: boolean;
  tags: string[];
}
```

## 📘 참고 사항
기존 ArticleContent의 type 속성을 isQuestion으로 변경했습니다.
(기존 type: 'article' | 'question')

