### PR TITLE
[ 진욱 ] ChannelPage 구현, Card organism 구현

### DIFF
--- a/src/apis/article/createArticle.ts
+++ b/src/apis/article/createArticle.ts
@@ -1,0 +1,15 @@
+import { axiosInstance } from "@apis/axiosInstance";
+
+import { CreateArticleRequestBody } from "@type/apis/articles/CreateArticle";
+import { Article } from "@type/models/Article";
+
+import { DOMAIN } from "@constants/api";
+
+export const createArticle = async (article: CreateArticleRequestBody) => {
+  const { data } = await axiosInstance.post<Article>(
+    DOMAIN.CREATE_ARTICLE,
+    article
+  );
+
+  return data;
+};

--- a/src/apis/article/getArticlesByChannelId.ts
+++ b/src/apis/article/getArticlesByChannelId.ts
@@ -1,0 +1,21 @@
+import { axiosInstance } from "@apis/axiosInstance";
+
+import { GetArticlesResponse } from "@type/apis/articles/GetArticles";
+
+import { DOMAIN } from "@constants/api";
+
+export const getArticlesByChannelId = async (
+  channelId: string,
+  offset: number,
+  limit: number
+) => {
+  const { data } = await axiosInstance.get<GetArticlesResponse>(
+    DOMAIN.GET_ARTICLE.BY_CHANNEL_ID(channelId),
+    {
+      params: { offset, limit },
+      useAuth: false
+    }
+  );
+
+  return data;
+};

--- a/src/components/molecules/IconText.tsx
+++ b/src/components/molecules/IconText.tsx
@@ -1,3 +1,5 @@
+import { HTMLAttributes } from "react";
+
 import Flex from "@components/atoms/Flex";
 import Icon from "@components/atoms/Icon";
 import { IconProps } from "@components/atoms/Icon";
@@ -6,11 +8,12 @@ import { TextProps } from "@components/atoms/Text";
 
 const IconText = ({
   iconValue,
-  textValue
+  textValue,
+  ...props
 }: {
   iconValue: IconProps;
   textValue: TextProps;
-}) => {
+} & HTMLAttributes<HTMLDivElement>) => {
   const {
     Svg,
     size: iconSize = 20,
@@ -30,7 +33,7 @@ const IconText = ({
   } = textValue;
 
   return (
-    <Flex align="center">
+    <Flex align="center" {...props}>
       <Icon Svg={Svg} size={iconSize} fill={fill} {...iconProps} />
       <Text
         children={children}

--- a/src/components/molecules/Tag.tsx
+++ b/src/components/molecules/Tag.tsx
@@ -1,18 +1,25 @@
+import { HTMLAttributes } from "react";
+
 import Text from "@components/atoms/Text";
 
 import { useThemeStore } from "@stores/theme.store";
 
-type TagProps = {
-  size: number;
-  name: string;
-};
+import { Combine } from "@type/Combine";
 
-const Tag = ({ size = 12, name }: TagProps) => {
+type TagProps = Combine<
+  {
+    size: number;
+    name: string;
+  },
+  HTMLAttributes<HTMLElement>
+>;
+
+const Tag = ({ size = 12, name, ...props }: TagProps) => {
   const { theme } = useThemeStore();
   const tag = name.replace(/__/g, "");
 
   return (
-    <Text size={size} color={theme.PRIMARY}>
+    <Text size={size} color={theme.PRIMARY} {...props}>
       #{tag}
     </Text>
   );

--- a/src/components/organisms/Card/Card.styles.ts
+++ b/src/components/organisms/Card/Card.styles.ts
@@ -1,0 +1,26 @@
+import { css } from "@emotion/react";
+
+import { Theme } from "@constants/theme";
+
+export const getCardOuterStyle = (theme: Theme, width: number) => css`
+  width: ${width}px;
+  box-shadow: ${theme.SHADOW};
+  border-radius: 8px;
+  background-color: ${theme.BACKGROUND200};
+`;
+
+export const getCardSkeletionOuterStyle = (theme: Theme, width: number) => css`
+  width: ${width}px;
+  height: ${width * 1.3}px;
+  box-shadow: ${theme.SHADOW};
+  border-radius: 8px;
+  background-color: ${theme.BACKGROUND200};
+`;
+export const cardImgStyle = css`
+  cursor: pointer;
+`;
+
+export const userInfoStyle = css`
+  margin: 8px 0 0 8px;
+  cursor: pointer;
+`;

--- a/src/components/organisms/Card/Card.tsx
+++ b/src/components/organisms/Card/Card.tsx
@@ -1,0 +1,69 @@
+import { useNavigate } from "react-router-dom";
+
+import { css } from "@emotion/react";
+
+import Flex from "@components/atoms/Flex";
+import Image from "@components/atoms/Image";
+import UserInfo from "@components/molecules/UserInfo";
+
+import { useThemeStore } from "@stores/theme.store";
+
+import { Article } from "@type/models/Article";
+
+import { MIN_CARD_WIDTH } from "@constants/card";
+import { PATH } from "@constants/index";
+
+import mySvg from "@assets/svg/my.svg";
+
+import { cardImgStyle, getCardOuterStyle, userInfoStyle } from "./Card.styles";
+import CardFooter from "./CardFooter";
+
+type CardProps = {
+  width: number;
+  article: Article;
+};
+
+const Card = ({ article, width: w }: CardProps) => {
+  const { theme } = useThemeStore();
+  const navigate = useNavigate();
+
+  const width = Math.max(w, MIN_CARD_WIDTH);
+
+  return (
+    <Flex css={getCardOuterStyle(theme, width)} direction="column" gap={4}>
+      <UserInfo
+        imgWidth={24}
+        imageSrc={article.author.image || mySvg}
+        username={article.author.fullName}
+        fontSize={14}
+        css={userInfoStyle}
+        onClick={() => navigate(PATH.USER(article.author._id))}
+      />
+
+      {article.image ? (
+        <Image
+          width={width}
+          height={width * 0.6}
+          src={article.image}
+          alt="contentImg"
+          mode="cover"
+          css={cardImgStyle}
+          onClick={() => navigate(PATH.ARTICLE(article._id))}
+        />
+      ) : (
+        <div
+          css={css`
+            width: ${width}px;
+            height: ${width * 0.6}px;
+            cursor: pointer;
+          `}
+          onClick={() => navigate(PATH.ARTICLE(article._id))}
+        />
+      )}
+
+      <CardFooter article={article} />
+    </Flex>
+  );
+};
+
+export default Card;

--- a/src/components/organisms/Card/CardFooter.styles.ts
+++ b/src/components/organisms/Card/CardFooter.styles.ts
@@ -1,0 +1,22 @@
+import { css } from "@emotion/react";
+
+import { getLineClampStyle } from "@styles/lineClamp";
+
+export const cardFoorterOuterStyle = css`
+  padding: 8px;
+  width: calc(100% - 16px);
+`;
+
+export const cardDescriptionStyle = css`
+  cursor: pointer;
+`;
+
+export const titleStyle = css`
+  ${getLineClampStyle(1)}
+  margin: 2px;
+`;
+
+export const contentStyle = css`
+  ${getLineClampStyle(2)}
+  line-height: 20px;
+`;

--- a/src/components/organisms/Card/CardFooter.tsx
+++ b/src/components/organisms/Card/CardFooter.tsx
@@ -1,0 +1,95 @@
+import { useNavigate } from "react-router-dom";
+
+import { css } from "@emotion/react";
+
+import Flex from "@components/atoms/Flex";
+import Text from "@components/atoms/Text";
+import IconText from "@components/molecules/IconText";
+
+import { useThemeStore } from "@stores/theme.store";
+
+import {
+  Article,
+  articleTitleDataToArticleContent
+} from "@type/models/Article";
+
+import { PATH } from "@constants/index";
+
+import { Like, Message } from "@assets/svg";
+
+import {
+  cardDescriptionStyle,
+  cardFoorterOuterStyle,
+  contentStyle,
+  titleStyle
+} from "./CardFooter.styles";
+import Tags from "./Tags";
+
+type CardFooterProps = {
+  article: Article;
+};
+
+const CardFooter = ({ article }: CardFooterProps) => {
+  const { theme } = useThemeStore();
+  const navigate = useNavigate();
+
+  const { title, content, tags } = articleTitleDataToArticleContent(
+    article.title
+  );
+
+  return (
+    <Flex direction="column" gap={8} css={cardFoorterOuterStyle}>
+      <Flex
+        direction="column"
+        gap={8}
+        css={cardDescriptionStyle}
+        onClick={() => navigate(PATH.ARTICLE(article._id))}>
+        <Text size={16} strong={true} css={titleStyle}>
+          {title}
+        </Text>
+        <Text size={14} css={contentStyle}>
+          {content}
+        </Text>
+      </Flex>
+
+      <Tags tags={tags} />
+
+      <Text
+        size={12}
+        color={theme.type === "DARK" ? theme.TEXT100 : theme.TEXT300}>
+        {new Date(article.createdAt).toLocaleDateString()}
+      </Text>
+
+      <Flex
+        justify="space-between"
+        css={css`
+          width: 100%;
+        `}>
+        <IconText
+          iconValue={{ Svg: Like, fill: theme.TEXT300, size: 16 }}
+          textValue={{
+            children: article.likes.length,
+            size: 12,
+            color: theme.TEXT300
+          }}
+          css={css`
+            gap: 5px;
+          `}
+        />
+        <IconText
+          iconValue={{ Svg: Message, fill: theme.TEXT300, size: 16 }}
+          textValue={{
+            children: article.comments.length,
+            size: 12,
+            color: theme.TEXT300
+          }}
+          css={css`
+            gap: 5px;
+          `}
+        />
+      </Flex>
+    </Flex>
+  );
+};
+
+export default CardFooter;

--- a/src/components/organisms/Card/CardSkeleton.tsx
+++ b/src/components/organisms/Card/CardSkeleton.tsx
@@ -1,0 +1,15 @@
+import { useThemeStore } from "@stores/theme.store";
+
+import { MIN_CARD_WIDTH } from "@constants/card";
+
+import { getCardSkeletionOuterStyle } from "./Card.styles";
+
+const CardSkeleton = ({ width: w }: { width: number }) => {
+  const { theme } = useThemeStore();
+
+  const width = Math.max(w, MIN_CARD_WIDTH);
+
+  return <div css={getCardSkeletionOuterStyle(theme, width)}></div>;
+};
+
+export default CardSkeleton;

--- a/src/components/organisms/Card/Tags.styles.ts
+++ b/src/components/organisms/Card/Tags.styles.ts
@@ -1,0 +1,13 @@
+import { css } from "@emotion/react";
+
+export const tagsContainerStyle = css`
+  width: calc(100% - 16px);
+  overflow: hidden;
+`;
+
+export const tagStyle = css`
+  cursor: pointer;
+  :hover {
+    filter: brightness(1.3);
+  }
+`;

--- a/src/components/organisms/Card/Tags.tsx
+++ b/src/components/organisms/Card/Tags.tsx
@@ -1,0 +1,35 @@
+import { createSearchParams, useNavigate } from "react-router-dom";
+
+import Flex from "@components/atoms/Flex";
+import Tag from "@components/molecules/Tag";
+
+import { PATH } from "@constants/index";
+
+import { tagStyle, tagsContainerStyle } from "./Tags.styles";
+
+const Tags = ({ tags }: { tags: string[] }) => {
+  const navigate = useNavigate();
+
+  return (
+    <Flex gap={5} css={tagsContainerStyle}>
+      {tags.map((tag, i) => (
+        <Tag
+          key={`${tag}${i}`}
+          size={12}
+          name={tag}
+          css={tagStyle}
+          onClick={() =>
+            navigate({
+              pathname: PATH.SEARCH,
+              search: createSearchParams({
+                tag
+              }).toString()
+            })
+          }
+        />
+      ))}
+    </Flex>
+  );
+};
+
+export default Tags;

--- a/src/components/organisms/Card/index.ts
+++ b/src/components/organisms/Card/index.ts
@@ -1,0 +1,2 @@
+export { default as Card } from "./Card";
+export { default as CardSkeleton } from "./CardSkeleton";

--- a/src/components/templates/PageTemplate/PageTemplate.styles.ts
+++ b/src/components/templates/PageTemplate/PageTemplate.styles.ts
@@ -1,6 +1,10 @@
 import { css } from "@emotion/react";
 
 export const pageTemplateWrapperStyle = css`
-  gap: 20px;
   position: relative;
+  overflow-x: hidden;
+`;
+
+export const pageInnerWrapperStyle = css`
+  margin-left: 330px;
 `;

--- a/src/components/templates/PageTemplate/PageTemplate.tsx
+++ b/src/components/templates/PageTemplate/PageTemplate.tsx
@@ -6,7 +6,10 @@ import Button from "@components/atoms/Button";
 import Flex from "@components/atoms/Flex";
 import Icon from "@components/atoms/Icon";
 import Text from "@components/atoms/Text";
-import { pageTemplateWrapperStyle } from "@components/templates/PageTemplate/PageTemplate.styles";
+import {
+  pageInnerWrapperStyle,
+  pageTemplateWrapperStyle
+} from "@components/templates/PageTemplate/PageTemplate.styles";
 
 import { useThemeStore } from "@stores/theme.store";
 
@@ -21,7 +24,7 @@ const PageTemplate = () => {
       <Flex
         direction="column"
         css={css`
-          position: sticky;
+          position: fixed;
           height: 100vh;
           top: 0;
           left: 0;
@@ -30,7 +33,7 @@ const PageTemplate = () => {
           css={css`
             margin: 20px;
             padding: 10px;
-            width: 300px;
+            width: 256px;
             flex-grow: 1;
             border: 1px solid var(--border-color);
             border-radius: 8px;
@@ -45,7 +48,9 @@ const PageTemplate = () => {
           <Button onClick={toggleTheme}>toggle theme</Button>
         </nav>
       </Flex>
-      <Outlet />
+      <div css={pageInnerWrapperStyle}>
+        <Outlet />
+      </div>
     </Flex>
   );
 };

--- a/src/constants/card.ts
+++ b/src/constants/card.ts
@@ -1,0 +1,1 @@
+export const MIN_CARD_WIDTH = 200;

--- a/src/hooks/api/useArticlesByChannelIdQuery.ts
+++ b/src/hooks/api/useArticlesByChannelIdQuery.ts
@@ -1,0 +1,18 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import { getArticlesByChannelId } from "@apis/article/getArticlesByChannelId";
+
+const pageOffset = 20;
+
+export const useArticlesByChannelIdQuery = (channelId: string) => {
+  return useInfiniteQuery(
+    ["articles", channelId],
+    ({ pageParam }) => getArticlesByChannelId(channelId, pageParam, pageOffset),
+    {
+      getNextPageParam: (lastPage, allPages) =>
+        lastPage.length === pageOffset ? allPages.length + 1 : undefined,
+      suspense: true,
+      useErrorBoundary: true
+    }
+  );
+};

--- a/src/hooks/api/useChannelsQuery.ts
+++ b/src/hooks/api/useChannelsQuery.ts
@@ -4,6 +4,7 @@ import { getChannels } from "@apis/channel/getChannels";
 
 export const useChannelsQuery = () => {
   const { data } = useQuery(["channels"], getChannels, {
+    staleTime: Infinity,
     suspense: true,
     useErrorBoundary: true
   });

--- a/src/pages/ChannelPage/ChannelPage.styles.ts
+++ b/src/pages/ChannelPage/ChannelPage.styles.ts
@@ -1,0 +1,14 @@
+import { css } from "@emotion/react";
+
+export const channelPageOuterStyle = css`
+  margin: 20px 0;
+`;
+
+export const channelPageHeaderStyle = css`
+  gap: 10px;
+`;
+
+export const cardListStyle = css`
+  margin-top: 30px;
+  flex-wrap: wrap;
+`;

--- a/src/pages/ChannelPage/ChannelPage.tsx
+++ b/src/pages/ChannelPage/ChannelPage.tsx
@@ -1,0 +1,59 @@
+import { useParams } from "react-router-dom";
+
+import Flex from "@components/atoms/Flex";
+import Text from "@components/atoms/Text";
+import Card from "@components/organisms/Card/Card";
+
+import { useArticlesByChannelIdQuery } from "@hooks/api/useArticlesByChannelIdQuery";
+import { useChannelsQuery } from "@hooks/api/useChannelsQuery";
+
+import { useThemeStore } from "@stores/theme.store";
+
+import ErrorBoundary from "@utils/ErrorBoundary";
+
+import {
+  cardListStyle,
+  channelPageHeaderStyle,
+  channelPageOuterStyle
+} from "./ChannelPage.styles";
+
+const ChannelPage = () => {
+  const { theme } = useThemeStore();
+  const { channelId } = useParams();
+
+  if (!channelId) {
+    throw new Error("channelId is undefined");
+  }
+
+  const { channels } = useChannelsQuery();
+  const { data } = useArticlesByChannelIdQuery(channelId);
+
+  const articles = data?.pages.reduce(
+    (articles, page) => [...articles, ...page],
+    []
+  );
+
+  const channel = channels.find((channel) => channel._id === channelId);
+
+  return (
+    <Flex direction="column" css={channelPageOuterStyle}>
+      <Flex align="center" css={channelPageHeaderStyle}>
+        <Text size={28} color={theme.TEXT300}>
+          채널
+        </Text>
+        <Text size={32} strong={true}>
+          {channel?.name}
+        </Text>
+      </Flex>
+      <Flex gap={30} css={cardListStyle}>
+        {articles?.map((article) => (
+          <ErrorBoundary fallback={null}>
+            <Card key={article._id} article={article} width={300} />
+          </ErrorBoundary>
+        ))}
+      </Flex>
+    </Flex>
+  );
+};
+
+export default ChannelPage;

--- a/src/pages/ChannelPage/ChannelPageSkeleton.tsx
+++ b/src/pages/ChannelPage/ChannelPageSkeleton.tsx
@@ -1,0 +1,34 @@
+import Flex from "@components/atoms/Flex";
+import Text from "@components/atoms/Text";
+import { CardSkeleton } from "@components/organisms/Card";
+
+import { useThemeStore } from "@stores/theme.store";
+
+import {
+  cardListStyle,
+  channelPageHeaderStyle,
+  channelPageOuterStyle
+} from "./ChannelPage.styles";
+
+const ChannelPageSkeleton = () => {
+  const { theme } = useThemeStore();
+
+  return (
+    <Flex direction="column" css={channelPageOuterStyle}>
+      <Flex align="center" css={channelPageHeaderStyle}>
+        <Text size={28} color={theme.TEXT300}>
+          채널
+        </Text>
+      </Flex>
+      <Flex gap={30} css={cardListStyle}>
+        {Array(20)
+          .fill(null)
+          .map(() => (
+            <CardSkeleton width={300} />
+          ))}
+      </Flex>
+    </Flex>
+  );
+};
+
+export default ChannelPageSkeleton;

--- a/src/pages/ChannelPage/index.ts
+++ b/src/pages/ChannelPage/index.ts
@@ -1,0 +1,2 @@
+export { default as ChannelPage } from "./ChannelPage";
+export { default as ChannelPageSkeleton } from "./ChannelPageSkeleton";

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,4 +1,7 @@
+import { Suspense } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+
+import { ChannelPage, ChannelPageSkeleton } from "@pages/ChannelPage";
 
 import { PageTemplate } from "@components/templates/PageTemplate";
 
@@ -12,7 +15,11 @@ const AppRouter = () => {
           <Route path={PATH.HOME} element={<div>home</div>} />
           <Route
             path={PATH.CHANNEL(":channelId")}
-            element={<div>channel</div>}
+            element={
+              <Suspense fallback={<ChannelPageSkeleton />}>
+                <ChannelPage />
+              </Suspense>
+            }
           />
           <Route
             path={PATH.ARTICLE(":articleId")}

--- a/src/stories/components/organisms/Card.stories.tsx
+++ b/src/stories/components/organisms/Card.stories.tsx
@@ -1,0 +1,46 @@
+import { BrowserRouter } from "react-router-dom";
+
+import { Meta, StoryObj } from "@storybook/react";
+
+import { Card } from "@components/organisms/Card";
+
+import { Article } from "@type/models/Article";
+
+const meta = {
+  title: "components/organisms/Card",
+  component: Card,
+  decorators: [
+    (Story) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    )
+  ],
+  tags: ["autodocs"],
+  argTypes: {
+    width: { control: { type: "range", min: 0, max: 500 } }
+  }
+} satisfies Meta<typeof Card>;
+
+export default meta;
+
+export const Default: StoryObj<typeof meta> = {
+  render: (args) => <Card {...args} />,
+  args: {
+    width: 300,
+    article: {
+      _id: "kajskldjl123",
+      title: JSON.stringify({
+        title:
+          "제목입니다제목입니다제목입니다제목입니다제목입니다제목입니다제목입니다",
+        content:
+          "내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다",
+        tags: ["__react__", "__javascript__"]
+      }),
+      likes: [1, 2, 3, 4, 5],
+      comments: [1, 2, 3, 4, 5],
+      createdAt: new Date().toLocaleDateString(),
+      author: { _id: "ahjskld", fullName: "jinwook" }
+    } as unknown as Article
+  }
+};

--- a/src/styles/lineClamp.ts
+++ b/src/styles/lineClamp.ts
@@ -1,0 +1,8 @@
+import { css } from "@emotion/react";
+
+export const getLineClampStyle = (clamp: number) => css`
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: ${clamp};
+`;

--- a/src/types/apis/articles/CreateArticle.ts
+++ b/src/types/apis/articles/CreateArticle.ts
@@ -1,7 +1,7 @@
-import { ArticleContent } from "@type/models/Article";
+import { ArticleTitleData } from "@type/models/Article";
 
 export interface CreateArticleRequestBody {
-  title: ArticleContent;
+  title: ArticleTitleData;
   image?: BinaryData | null;
   channelId: string;
 }

--- a/src/types/apis/articles/UpdateArticle.ts
+++ b/src/types/apis/articles/UpdateArticle.ts
@@ -1,8 +1,8 @@
-import { ArticleContent } from "@type/models/Article";
+import { ArticleTitleData } from "@type/models/Article";
 
 export interface UpdateArticleRequestBody {
   postId: string;
-  title: ArticleContent;
+  title: ArticleTitleData;
   image?: BinaryData | null;
   imageToDeletePublicId?: string;
   channelId: string;

--- a/src/types/models/Article.ts
+++ b/src/types/models/Article.ts
@@ -9,13 +9,27 @@ export interface ArticleContent {
   tags: string[];
 }
 
+export type ArticleTitleData = string & { label: "articleTitle" };
+
+export function articleContentToArticleTitleData(
+  articleContent: ArticleContent
+): ArticleTitleData {
+  return JSON.stringify(articleContent) as ArticleTitleData;
+}
+
+export function articleTitleDataToArticleContent(
+  articletitleData: ArticleTitleData
+): ArticleContent {
+  return JSON.parse(articletitleData);
+}
+
 export interface Article {
   likes: Like[];
   comments: Comment[];
   _id: string;
   image?: string;
   imagePublicId?: string;
-  title: ArticleContent;
+  title: ArticleTitleData;
   channel: Channel;
   author: User;
   createdAt: string;

--- a/src/types/models/User.ts
+++ b/src/types/models/User.ts
@@ -3,8 +3,8 @@ import { Like } from "./Like";
 import { Message } from "./Message";
 
 export interface User {
-  coverImage: string;
-  image: string;
+  coverImage?: string;
+  image?: string;
   role: string;
   emailVerified: boolean;
   banned: boolean;

--- a/src/utils/ErrorBoundary.ts
+++ b/src/utils/ErrorBoundary.ts
@@ -1,0 +1,34 @@
+import { Component, ErrorInfo } from "react";
+
+interface Props {
+  fallback: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false
+  };
+
+  public static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Uncaught error:", error, errorInfo);
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## 📌 이슈 번호
close #37 
close #36 

## 🚀 구현 내용
- Card organism 구현
- ChannelPage 구현
- PageTemplate 버그 수정
- 모델 타입선언 조금 수정 

## 📘 참고 사항
Article 모델의 경우 title 속성의 타입이 ArticleTitleData 입니다. 
ArticleContent를 stringify 한 것이 ArticleTitleData가 됩니다.
제가 만들어둔 변환 함수를 써야 타입 추론이 됩니다.

ArticleTitleData 예시
```ts
'{"title":"제목입니다제목입니다제목입니다제목입니다제목입니다","content":"내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다","isQuestion":false,"tags":["__react__","__typescript__"]}'
```
ArticleContent 예시
```ts
{
  title:'제목입니다제목입니다제목입니다제목입니다제목입니다', 
  content: '내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다내용입니다', 
  isQuestion: false,
  tags: ['__react__', '__typescript__']
}
```

