### PR TITLE
[ 진욱 ] 카드 컴포넌트 텍스트 overflow 되는 문제 수정

### DIFF
--- a/src/components/organisms/Card/CardFooter.styles.ts
+++ b/src/components/organisms/Card/CardFooter.styles.ts
@@ -24,3 +24,7 @@ export const contentStyle = css`
   ${getLineClampStyle(2)}
   line-height: 20px;
 `;
+
+export const tagsHeightStyle = css`
+  height: 18px;
+`;

--- a/src/components/organisms/Card/CardFooter.styles.ts
+++ b/src/components/organisms/Card/CardFooter.styles.ts
@@ -8,16 +8,19 @@ export const cardFoorterOuterStyle = css`
 `;
 
 export const cardDescriptionStyle = css`
+  width: 100%;
   cursor: pointer;
 `;
 
 export const titleStyle = css`
+  width: 100%;
   ${getLineClampStyle(1)}
   line-height: 20px;
   margin: 2px;
 `;
 
 export const contentStyle = css`
+  width: 100%;
   ${getLineClampStyle(2)}
   line-height: 20px;
 `;

--- a/src/components/organisms/Card/CardFooter.tsx
+++ b/src/components/organisms/Card/CardFooter.tsx
@@ -24,6 +24,7 @@ import {
   cardDescriptionStyle,
   cardFoorterOuterStyle,
   contentStyle,
+  tagsHeightStyle,
   titleStyle
 } from "./CardFooter.styles";
 
@@ -56,7 +57,11 @@ const CardFooter = ({ article }: CardFooterProps) => {
         </Text>
       </Flex>
 
-      <Tags tags={tags} />
+      {tags.length === 0 ? (
+        <div css={tagsHeightStyle}></div>
+      ) : (
+        <Tags tags={tags} />
+      )}
 
       <Text
         size={12}


### PR DESCRIPTION
## 📌 이슈 번호
close #84 

## 🚀 구현 내용
- [카드 Footer 너비 속성 누락된 것 추가](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/e451b44c1fd5cb42c370e42f6fe9054b2aa269ab)
- [CardFooter 컴포넌트, 태그가 없을 때 기본 높이 추가](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/d961a80a58c6a6d12fa8099f9e5d592930180313)

