### PR TITLE
[ 진욱 ] 채널 페이지 무한스크롤 구현

### DIFF
--- a/src/hooks/api/useArticlesByChannelIdQuery.ts
+++ b/src/hooks/api/useArticlesByChannelIdQuery.ts
@@ -2,15 +2,18 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 
 import { getArticlesByChannelId } from "@apis/article/getArticlesByChannelId";
 
-const pageOffset = 20;
+const PAGE_LIMIT = 20;
 
 export const useArticlesByChannelIdQuery = (channelId: string) => {
   return useInfiniteQuery(
     ["articles", channelId],
-    ({ pageParam }) => getArticlesByChannelId(channelId, pageParam, pageOffset),
+    ({ pageParam = 0 }) =>
+      getArticlesByChannelId(channelId, pageParam, PAGE_LIMIT),
     {
       getNextPageParam: (lastPage, allPages) =>
-        lastPage.length === pageOffset ? allPages.length + 1 : undefined,
+        lastPage.length === PAGE_LIMIT
+          ? allPages.length * PAGE_LIMIT
+          : undefined,
       staleTime: 10000,
       suspense: true,
       useErrorBoundary: true

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,27 @@
+import { RefObject, useEffect, useState } from "react";
+
+export function useIntersectionObserver(
+  ref: RefObject<HTMLElement>,
+  { threshold = 0, root = null, rootMargin = "0%" }: IntersectionObserverInit
+) {
+  const [entry, setEntry] = useState<IntersectionObserverEntry>();
+
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setEntry(entry);
+      },
+      { threshold, root, rootMargin }
+    );
+
+    observer.observe(ref.current);
+
+    return () => observer.disconnect();
+  }, [ref, threshold, root, rootMargin]);
+
+  return entry;
+}


### PR DESCRIPTION
## 📌 이슈 번호
close #92 

## 🚀 구현 내용
- [fix: useInfiniteQuery 내부 로직 잘못되어 있던 것 수정](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/5f5c9c2f261a2efb35e261004f51ee97958fc2c3)
- [feat: useIntersectionObserver 훅 구현](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/6a3a6f6e750a0648f7b07a48da85f38f65a19a5a)
- [feat: 채널 페이지 무한스크롤 구현](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/fe4d2a2b769ad16f4921752909ed78ed483b4772)

## 📘 참고 사항
유저 페이지나 홈페이지에서도 무한스크롤이 되어야 해서
공통로직이 있을 것 같네요
무한스크롤 부분을 컴포넌트로 분리하면 좋을까요?