### PR TITLE
[ 혜수 ] 글 수정 페이지 기존 작성 글 불러오는 기능 추가

### DIFF
--- a/src/apis/article/updateArticle.ts
+++ b/src/apis/article/updateArticle.ts
@@ -1,0 +1,15 @@
+import { axiosInstance } from "@apis/axiosInstance";
+
+import { UpdateArticleRequestBody } from "@type/apis/articles/UpdateArticle";
+import { Article } from "@type/models/Article";
+
+import { DOMAIN } from "@constants/api";
+
+export const updateArticle = async (article: UpdateArticleRequestBody) => {
+  const { data } = await axiosInstance.put<Article>(
+    DOMAIN.UPDATE_ARTICLE,
+    article
+  );
+
+  return data;
+};

--- a/src/components/organisms/ArticleWrite/ArticleChannelSelect.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleChannelSelect.tsx
@@ -34,17 +34,24 @@ const Select = ({
 
 interface ArticleChannelSelectProps {
   stateChange: (value: string) => void;
+  state?: string;
 }
-const ArticleChannelSelect = ({ stateChange }: ArticleChannelSelectProps) => {
+const ArticleChannelSelect = ({
+  stateChange,
+  state
+}: ArticleChannelSelectProps) => {
   const dropdownRef = useRef(null);
-  const [channelIdentify, setChannelIdentify] = useState("채널 선택");
-  const { theme } = useThemeStore();
   const channelList = [...useChannelsQuery().channels];
+  const Mychannel = channelList.filter((x) => x._id === state);
+  const [channelIdentify, setChannelIdentify] = useState(
+    state ? Mychannel[0].name : "채널 선택"
+  );
+  const { theme } = useThemeStore();
   const [isOpen, setIsOpen] = useDetectClose(dropdownRef, false);
   const selectedChannel = channelList.find((x) => x.name === channelIdentify);
 
   useEffect(() => {
-    stateChange(selectedChannel ? selectedChannel._id : "");
+    stateChange(selectedChannel ? selectedChannel._id : state ? state : "");
   });
 
   return (

--- a/src/components/organisms/ArticleWrite/ArticleEdit.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleEdit.tsx
@@ -39,7 +39,6 @@ const ArticleEdit = () => {
   const [tags, setTags] = useState<string[]>([...preTags]);
   const [content, setContent] = useState(preContent);
   const { theme } = useThemeStore();
-
   if (!isLoggedIn) dispatchError(new AuthError("로그인이 필요합니다."));
 
   const navigatePage = (page: string) => {
@@ -81,6 +80,8 @@ const ArticleEdit = () => {
         theme={theme}
         navigatePage={navigatePage}
         totalContent={{ title, channelId, content, tags }}
+        postId={article._id}
+        purpose="edit"
       />
     </Flex>
   );

--- a/src/components/organisms/ArticleWrite/ArticleEdit.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleEdit.tsx
@@ -40,7 +40,7 @@ const ArticleEdit = () => {
   const [content, setContent] = useState(preContent);
   const { theme } = useThemeStore();
 
-  console.log(channelId, title, tags, content);
+  console.log("현재 정보", channelId, title, tags, content);
 
   if (!isLoggedIn) dispatchError(new AuthError("로그인이 필요합니다."));
 
@@ -66,6 +66,7 @@ const ArticleEdit = () => {
       />
       <ArticleWriteTitle
         stateChange={(value) => setTitle(value)}
+        state={title}
         width={width}
       />
       <ArticleWriteTag stateChange={(value) => setTags(value)} width={width} />

--- a/src/components/organisms/ArticleWrite/ArticleEdit.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleEdit.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { css } from "@emotion/react";
+
+import Flex from "@components/atoms/Flex";
+
+import { useArticleQuery } from "@hooks/api/useArticleQuery";
+import { useError } from "@hooks/useError";
+import { useLoggedIn } from "@hooks/useLoggedIn";
+
+import { useThemeStore } from "@stores/theme.store";
+
+import { articleTitleDataToArticleContent } from "@type/models/Article";
+
+import { AuthError } from "@utils/AuthError";
+
+import ArticleChannelSelect from "./ArticleChannelSelect";
+import ArticleWriteButtons from "./ArticleWriteButtons";
+import ArticleWriteEditor from "./ArticleWriteEditor";
+import ArticleWriteTag from "./ArticleWriteTag";
+import ArticleWriteTitle from "./ArticleWriteTitle";
+
+const ArticleEdit = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const articleId = location.pathname.split("/")[2];
+  const { dispatchError } = useError();
+  const { isLoggedIn } = useLoggedIn();
+  const { article } = useArticleQuery(articleId);
+  const {
+    title: preTitle,
+    content: preContent,
+    tags: preTags
+  } = articleTitleDataToArticleContent(article.title);
+  const [channelId, setChannelId] = useState(articleId);
+  const [title, setTitle] = useState(preTitle);
+  const [tags, setTags] = useState<string[]>([...preTags]);
+  const [content, setContent] = useState(preContent);
+  const { theme } = useThemeStore();
+
+  console.log(channelId, title, tags, content);
+
+  if (!isLoggedIn) dispatchError(new AuthError("로그인이 필요합니다."));
+
+  const navigatePage = (page: string) => {
+    switch (page) {
+      case "CHANNEL":
+        return navigate(`/channels/${channelId}`);
+      case "BACK":
+        return navigate(-1);
+    }
+  };
+  const width = "70%";
+
+  return (
+    <Flex
+      direction="column"
+      css={css`
+        margin: 20px;
+      `}>
+      <ArticleChannelSelect stateChange={(value) => setChannelId(value)} />
+      <ArticleWriteTitle
+        stateChange={(value) => setTitle(value)}
+        width={width}
+      />
+      <ArticleWriteTag stateChange={(value) => setTags(value)} width={width} />
+      <ArticleWriteEditor
+        stateChange={(value) => setContent(value)}
+        width={width}
+      />
+      <ArticleWriteButtons
+        theme={theme}
+        navigatePage={navigatePage}
+        totalContent={{ title, channelId, content, tags }}
+      />
+    </Flex>
+  );
+};
+
+export default ArticleEdit;

--- a/src/components/organisms/ArticleWrite/ArticleEdit.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleEdit.tsx
@@ -40,8 +40,6 @@ const ArticleEdit = () => {
   const [content, setContent] = useState(preContent);
   const { theme } = useThemeStore();
 
-  console.log("현재 정보", channelId, title, tags, content);
-
   if (!isLoggedIn) dispatchError(new AuthError("로그인이 필요합니다."));
 
   const navigatePage = (page: string) => {
@@ -76,6 +74,7 @@ const ArticleEdit = () => {
       />
       <ArticleWriteEditor
         stateChange={(value) => setContent(value)}
+        state={content}
         width={width}
       />
       <ArticleWriteButtons

--- a/src/components/organisms/ArticleWrite/ArticleEdit.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleEdit.tsx
@@ -24,10 +24,11 @@ import ArticleWriteTitle from "./ArticleWriteTitle";
 const ArticleEdit = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const articleId = location.pathname.split("/")[2];
+
   const { dispatchError } = useError();
   const { isLoggedIn } = useLoggedIn();
-  const { article } = useArticleQuery(articleId);
+  const { article } = useArticleQuery(location.pathname.split("/")[2]);
+  const articleId = article.channel._id;
   const {
     title: preTitle,
     content: preContent,
@@ -59,7 +60,10 @@ const ArticleEdit = () => {
       css={css`
         margin: 20px;
       `}>
-      <ArticleChannelSelect stateChange={(value) => setChannelId(value)} />
+      <ArticleChannelSelect
+        stateChange={(value) => setChannelId(value)}
+        state={channelId}
+      />
       <ArticleWriteTitle
         stateChange={(value) => setTitle(value)}
         width={width}

--- a/src/components/organisms/ArticleWrite/ArticleEdit.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleEdit.tsx
@@ -69,7 +69,11 @@ const ArticleEdit = () => {
         state={title}
         width={width}
       />
-      <ArticleWriteTag stateChange={(value) => setTags(value)} width={width} />
+      <ArticleWriteTag
+        stateChange={(value) => setTags(value)}
+        state={tags}
+        width={width}
+      />
       <ArticleWriteEditor
         stateChange={(value) => setContent(value)}
         width={width}

--- a/src/components/organisms/ArticleWrite/ArticleWrite.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWrite.tsx
@@ -60,6 +60,7 @@ const ArticleWrite = () => {
         theme={theme}
         navigatePage={navigatePage}
         totalContent={{ title, channelId, content, tags }}
+        purpose="create"
       />
     </Flex>
   );

--- a/src/components/organisms/ArticleWrite/ArticleWriteButtons.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWriteButtons.tsx
@@ -78,10 +78,9 @@ const ArticleWriteButtons = ({
         color={theme.TEXT600}
         onClick={() => navigatePage("BACK")}></Button>
       <Button
-        children="완료"
+        children={purpose === "create" ? "생성" : "수정"}
         width="50px"
         height="30px"
-        color={theme.TEXT100}
         onClick={handleCreateButtonClick}></Button>
     </Flex>
   );

--- a/src/components/organisms/ArticleWrite/ArticleWriteButtons.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWriteButtons.tsx
@@ -42,6 +42,10 @@ const ArticleWriteButtons = ({
         channelId: channelId
       });
       navigatePage("CHANNEL");
+    } else if (!title && channelId) {
+      toast.error("제목을 입력해 주세요.");
+    } else if (title && !channelId) {
+      toast.error("채널을 선택해 주세요.");
     } else {
       toast.error("채널 선택과 제목 입력은 필수사항입니다.");
     }

--- a/src/components/organisms/ArticleWrite/ArticleWriteButtons.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWriteButtons.tsx
@@ -4,6 +4,7 @@ import Button from "@components/atoms/Button";
 import Flex from "@components/atoms/Flex";
 
 import { useArticleCreateMutation } from "@hooks/api/useArticleCreateMutation";
+import { useArticleUpdateMutation } from "@hooks/api/useArticleUpdateMutation";
 
 import { articleContentToArticleTitleData } from "@type/models/Article";
 
@@ -22,25 +23,42 @@ type ArticleWriteButtonsProps = {
   theme: Theme;
   navigatePage: (page: string) => void;
   totalContent: totalContentType;
+  postId?: string;
+  purpose: string;
 };
 
 const ArticleWriteButtons = ({
   theme,
   navigatePage,
-  totalContent
+  totalContent,
+  postId,
+  purpose
 }: ArticleWriteButtonsProps) => {
-  const { mutate } = useArticleCreateMutation();
+  const { mutate: cretateMutate } = useArticleCreateMutation();
+  const { mutate: updateMutate } = useArticleUpdateMutation();
   const { title, channelId, content, tags } = totalContent;
   const handleCreateButtonClick = () => {
     if (title && channelId) {
-      mutate({
-        title: articleContentToArticleTitleData({
-          title,
-          content,
-          tags
-        }),
-        channelId: channelId
-      });
+      {
+        purpose === "create"
+          ? cretateMutate({
+              title: articleContentToArticleTitleData({
+                title,
+                content,
+                tags
+              }),
+              channelId: channelId
+            })
+          : updateMutate({
+              postId: postId as string,
+              title: articleContentToArticleTitleData({
+                title,
+                content,
+                tags
+              }),
+              channelId: channelId
+            });
+      }
       navigatePage("CHANNEL");
     } else if (!title && channelId) {
       toast.error("제목을 입력해 주세요.");

--- a/src/components/organisms/ArticleWrite/ArticleWriteEditor.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWriteEditor.tsx
@@ -6,6 +6,7 @@ import { CKEditor } from "@ckeditor/ckeditor5-react";
 
 interface ArticleEditorProps {
   stateChange: (value: string) => void;
+  state?: string;
   width: string;
 }
 // const editorConfiguration = {
@@ -19,7 +20,7 @@ class ArticleEditor extends React.Component<ArticleEditorProps> {
           config={{ language: "ko" }}
           editor={ClassicEditor}
           // config={editorConfiguration}
-          data=""
+          data={this.props.state ? this.props.state : ""}
           // onReady={(editor) => {
           //   // You can store the "editor" and use when it is needed.
           //   console.log("Editor is ready to use!", editor);

--- a/src/components/organisms/ArticleWrite/ArticleWriteTag.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWriteTag.tsx
@@ -17,6 +17,19 @@ const ArticleTag = ({ stateChange, state, width }: ArticleTagProps) => {
   const [inputValue, setInputValue] = useState("");
   const [tags, setTags] = useState<string[]>(state ? [...state] : []);
   const { theme } = useThemeStore();
+
+  const addToSet = (value: string) => {
+    const updatedSet = new Set(tags);
+    updatedSet.add(value);
+    setTags([...updatedSet]);
+  };
+
+  const removeFromSet = (value: string) => {
+    const updatedSet = new Set(tags);
+    updatedSet.delete(value);
+    setTags([...updatedSet]);
+  };
+
   useEffect(() => {
     stateChange(tags);
   });
@@ -36,7 +49,7 @@ const ArticleTag = ({ stateChange, state, width }: ArticleTagProps) => {
         onKeyUp={(e: React.KeyboardEvent<HTMLInputElement>) => {
           if (e.nativeEvent.isComposing || !inputValue) return;
           if (e.key === "Enter") {
-            setTags([...tags, `__${inputValue}__`]);
+            addToSet(`__${inputValue}__`);
             setInputValue("");
           }
         }}
@@ -56,7 +69,7 @@ const ArticleTag = ({ stateChange, state, width }: ArticleTagProps) => {
               size={16}
               name={tag}
               onClick={() => {
-                setTags([...tags].filter((x) => x !== tag));
+                removeFromSet(tag);
               }}
             />
           );

--- a/src/components/organisms/ArticleWrite/ArticleWriteTag.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWriteTag.tsx
@@ -34,7 +34,6 @@ const ArticleTag = ({ stateChange, state, width }: ArticleTagProps) => {
           setInputValue(e.target.value)
         }
         onKeyUp={(e: React.KeyboardEvent<HTMLInputElement>) => {
-          console.log(e);
           if (e.nativeEvent.isComposing || !inputValue) return;
           if (e.key === "Enter") {
             setTags([...tags, `__${inputValue}__`]);

--- a/src/components/organisms/ArticleWrite/ArticleWriteTag.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWriteTag.tsx
@@ -10,11 +10,12 @@ import { useThemeStore } from "@stores/theme.store";
 
 interface ArticleTagProps {
   stateChange: (value: string[]) => void;
+  state?: string[];
   width: string;
 }
-const ArticleTag = ({ stateChange, width }: ArticleTagProps) => {
+const ArticleTag = ({ stateChange, state, width }: ArticleTagProps) => {
   const [inputValue, setInputValue] = useState("");
-  const [tags, setTags] = useState<string[]>([]);
+  const [tags, setTags] = useState<string[]>(state ? [...state] : []);
   const { theme } = useThemeStore();
   useEffect(() => {
     stateChange(tags);

--- a/src/components/organisms/ArticleWrite/ArticleWriteTitle.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWriteTitle.tsx
@@ -8,10 +8,11 @@ import { useThemeStore } from "@stores/theme.store";
 
 interface ArticleTagProps {
   stateChange: (value: string) => void;
+  state?: string;
   width: string;
 }
-const ArticleTitle = ({ stateChange, width }: ArticleTagProps) => {
-  const [inputValue, setInputValue] = useState("");
+const ArticleTitle = ({ stateChange, state, width }: ArticleTagProps) => {
+  const [inputValue, setInputValue] = useState(state ? state : "");
   const { theme } = useThemeStore();
   useEffect(() => {
     stateChange(inputValue);

--- a/src/components/organisms/ArticleWrite/index.tsx
+++ b/src/components/organisms/ArticleWrite/index.tsx
@@ -1,1 +1,2 @@
 export { default as ArticleWrite } from "./ArticleWrite";
+export { default as ArticleEdit } from "./ArticleEdit";

--- a/src/hooks/api/useArticleUpdateMutation.ts
+++ b/src/hooks/api/useArticleUpdateMutation.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { updateArticle } from "@apis/article/updateArticle";
+
+export const useArticleUpdateMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateArticle,
+    onSuccess: (article) =>
+      Promise.all([
+        queryClient.invalidateQueries(["articles", article.channel._id]),
+        queryClient.invalidateQueries(["user-by-token"])
+      ])
+  });
+};

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -10,7 +10,7 @@ import SignUpPage from "@pages/SignUpPage";
 import UserPage from "@pages/UserPage/UserPage";
 
 import { Article, ArticleSkeleton } from "@components/organisms/Article";
-import { ArticleWrite } from "@components/organisms/ArticleWrite";
+import { ArticleEdit, ArticleWrite } from "@components/organisms/ArticleWrite";
 import { PageTemplate } from "@components/templates/PageTemplate";
 
 import { PATH } from "@constants/index";
@@ -39,7 +39,7 @@ const AppRouter = () => {
         <Route path={PATH.CREATE_ARTICLE} element={<ArticleWrite />} />
         <Route
           path={PATH.EDIT_ARTICLE(":articleId")}
-          element={<ArticleWrite />}
+          element={<ArticleEdit />}
         />
         <Route path={PATH.SEARCH} element={<div>search</div>} />
         <Route path={PATH.USER(":userId")} element={<UserPage />} />


### PR DESCRIPTION
## 📌 이슈 번호
close #81 
## 🚀 구현 내용
- #81 
- Article edit 생성
- ArticleUpdate api 생성
- 아티클 수정할 때 기존에 작성된 채널, 타이틀, 태그, 내용 전부 유지
- 토스트 발생조건 추가
- 글 수정, 생성시 버튼 글자 다르게 수정
- 태그 중복되지 않도록 set 이용
## 📘 참고 사항
- 누군가 feature#81 브랜치를 파놨습니다. 그래서 hs추가했습니다.
## ❓ 궁금한 내용

## ETC
