### PR TITLE
[ 동현 ] 빈 문자열로 댓글을 추가 할 시, 에러 발생

### DIFF
--- a/src/components/molecules/CommentForm.tsx
+++ b/src/components/molecules/CommentForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import toast from "react-hot-toast";
 
 import { css } from "@emotion/react";
 
@@ -30,6 +31,10 @@ const CommentForm = ({ width, articleId }: CommentFormProps) => {
     setComment(value);
   };
   const handleSubmitComment = () => {
+    if (comment === "") {
+      toast.error("댓글에 내용을 입력해주세요.");
+      return;
+    }
     commentCreateMutate(
       { comment, postId: articleId },
       {

--- a/src/hooks/api/useCommentCreateMutation.ts
+++ b/src/hooks/api/useCommentCreateMutation.ts
@@ -1,3 +1,5 @@
+import toast from "react-hot-toast";
+
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { createComment } from "@apis/comment/createComment";
@@ -9,6 +11,9 @@ export const useCommentCreateMutation = () => {
     mutationFn: createComment,
     onSuccess: (comment) => {
       queryClient.invalidateQueries(["article", comment.post]);
+    },
+    onError: () => {
+      toast.error("댓글을 추가하던 중 오류가 발생하였습니다.");
     }
   });
 };


### PR DESCRIPTION
## 📌 이슈 번호
close #136 
## 🚀 구현 내용
- 빈 문자열로 작성시 댓글을 제출 할 수 없도록 막기
- API를 호출하다가 발생한 에러를 toast UI로 띄우기
## 📘 참고 사항
react-query의 전역 설정으로
mutation에 useErrorBoundary 가 true로 설정되어있어 원하는대로 동작이 이루어 지지 않습니다.
논의가 필요할 것 같습니다.
## ❓ 궁금한 내용

## ETC
