### PR TITLE
[ 진욱 ] 하트 아이콘 색 입히기

### DIFF
--- a/src/components/organisms/ArticleHeader/ArticleHeader.tsx
+++ b/src/components/organisms/ArticleHeader/ArticleHeader.tsx
@@ -119,7 +119,7 @@ const ArticleHeader = ({ article, tags, title }: ArticleHeaderProps) => {
           </Text>
         </Flex>
         <IconText
-          iconValue={{ Svg: Like, fill: myLike ? "red" : undefined }}
+          iconValue={{ Svg: Like, fill: myLike ? theme.SECONDARY : undefined }}
           textValue={{ size: 12, children: article.likes.length }}
           css={getLikeIconTextStyle(theme, isMyArticle)}
           onClick={handleLikeButtonClick}

--- a/src/components/organisms/Card/CardFooter.tsx
+++ b/src/components/organisms/Card/CardFooter.tsx
@@ -76,7 +76,11 @@ const CardFooter = ({ article }: CardFooterProps) => {
           width: 100%;
         `}>
         <IconText
-          iconValue={{ Svg: Like, fill: theme.TEXT300, size: 16 }}
+          iconValue={{
+            Svg: Like,
+            fill: theme.SECONDARY,
+            size: 16
+          }}
           textValue={{
             children: article.likes.length,
             size: 12,

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -9,6 +9,7 @@ export type Theme = Readonly<{
   TEXT600: string;
   SHADOW: string;
   PRIMARY: string;
+  SECONDARY: string;
 }>;
 
 export const LIGHT_MODE_THEME: Theme = {
@@ -21,7 +22,8 @@ export const LIGHT_MODE_THEME: Theme = {
   TEXT300: "#5C5E64",
   TEXT600: "#080C1E",
   SHADOW: "0px 0px 15px 0px rgba(0, 0, 0, 0.1)",
-  PRIMARY: "#007AFF"
+  PRIMARY: "#007AFF",
+  SECONDARY: "rgb(255, 30, 30)"
 };
 
 export const DARK_MODE_THEME: Theme = {
@@ -34,7 +36,8 @@ export const DARK_MODE_THEME: Theme = {
   TEXT300: "#CFCFCF",
   TEXT600: "#C0C0C0",
   SHADOW: "0px 0px 15px 0px rgba(0, 0, 0, 0.1)",
-  PRIMARY: "#007AFF"
+  PRIMARY: "#007AFF",
+  SECONDARY: "rgb(255, 100, 100)"
 };
 
 export const THEME_KEY = "THEME";


### PR DESCRIPTION
## 📌 이슈 번호
close #186 

## 🚀 구현 내용
- [feat: secondary 색상 추가(빨간색)](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/2ef47281c56040ef0ee6aa8302a319346adcba20)
- [feat: 카드 컴포넌트의 하트 색 입히기](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/07924589eef3bdbdaed7b2a8a44eed7b408e71eb)
- [feat: 아티클 컴포넌트의 하트 색 입히기](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/379e832686215ffa1d5952a617ef946650514419)

## 📘 참고 사항
theme.SECONDARY 는 빨간색입니다!
