### PR TITLE
[ 진욱 ] 자신의 게시글에 댓글 작성 시 알림 생성 방지

### DIFF
--- a/src/components/molecules/CommentForm.tsx
+++ b/src/components/molecules/CommentForm.tsx
@@ -43,12 +43,14 @@ const CommentForm = ({ width, article }: CommentFormProps) => {
       {
         onSuccess: (newComment) => {
           setComment("");
-          notificationCreateMutate({
-            notificationType: "COMMENT",
-            notificationTypeId: newComment._id,
-            postId: newComment.post,
-            userId: article.author._id
-          });
+          if (article.author._id !== data?._id) {
+            notificationCreateMutate({
+              notificationType: "COMMENT",
+              notificationTypeId: newComment._id,
+              postId: newComment.post,
+              userId: article.author._id
+            });
+          }
         }
       }
     );


### PR DESCRIPTION
## 📌 이슈 번호
close #192 
## 🚀 구현 내용
- [fix: 자신의 게시글에 댓글 작성 시 알림 생성 방지](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/1a40847ae7cd723a8d199cbd595f309617b507d9)
