### PR TITLE
[ 진욱 ] 카드, 검색결과, 게시글에 어느 채널인지 표시해주는 기능 추가

### DIFF
--- a/src/apis/search/searchArticles.ts
+++ b/src/apis/search/searchArticles.ts
@@ -1,3 +1,4 @@
+import { getChannels } from "@apis/channel/getChannels";
 import { getUser } from "@apis/user/getUser";
 
 import { ArticleSearchResult } from "@type/apis/etc/SearchAll";
@@ -6,7 +7,10 @@ import { Article } from "@type/models/Article";
 import { searchAll } from "./searchAll";
 
 export const searchArticles = async (searchKeyword: string) => {
-  const searchResults = await searchAll(searchKeyword);
+  const [searchResults, channels] = await Promise.all([
+    searchAll(searchKeyword),
+    getChannels()
+  ]);
   const articleSearchResults = searchResults.filter(
     (searchResult): searchResult is ArticleSearchResult =>
       "title" in searchResult
@@ -20,7 +24,8 @@ export const searchArticles = async (searchKeyword: string) => {
     (result, i) =>
       ({
         ...result,
-        author: users[i]
+        author: users[i],
+        channel: channels.find((channel) => channel._id === result.channel)
       }) as Article
   );
 };

--- a/src/components/molecules/UserInfo.tsx
+++ b/src/components/molecules/UserInfo.tsx
@@ -6,6 +6,8 @@ import Flex from "@components/atoms/Flex";
 import Image from "@components/atoms/Image";
 import Text from "@components/atoms/Text";
 
+import { getLineClampStyle } from "@styles/lineClamp";
+
 import { useThemeStore } from "@stores/theme.store";
 
 import { Combine } from "@type/Combine";
@@ -46,7 +48,7 @@ const UserInfo = ({
           border-radius: 50%;
         `}
       />
-      <Text size={fontSize} color={color}>
+      <Text size={fontSize} color={color} css={getLineClampStyle(1)}>
         {username}
       </Text>
     </Flex>

--- a/src/components/organisms/ArticleHeader/ArticleHeader.tsx
+++ b/src/components/organisms/ArticleHeader/ArticleHeader.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { toast } from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
 
+import { css } from "@emotion/react";
+
 import Flex from "@components/atoms/Flex";
 import Modal from "@components/atoms/Modal";
 import Text from "@components/atoms/Text";
@@ -14,6 +16,7 @@ import { useLikeCreateMutation } from "@hooks/api/useLikeCreateMutation";
 import { useLikeDeleteMutation } from "@hooks/api/useLikeDeleteMutation";
 import { useNotificationCreateMutation } from "@hooks/api/useNotificationCreateMutation";
 import { useUserByTokenQuery } from "@hooks/api/useUserByTokenQuery";
+import { useChannelName } from "@hooks/useChannelName";
 
 import { useThemeStore } from "@stores/theme.store";
 
@@ -43,6 +46,7 @@ const ArticleHeader = ({ article, tags, title }: ArticleHeaderProps) => {
   const navigate = useNavigate();
   const { data: myInfo } = useUserByTokenQuery();
   const [isOpen, setIsOpen] = useState(false);
+  const channelName = useChannelName(article.channel._id);
 
   const isMyArticle = myInfo?._id === article.author._id;
   const myLike = article.likes.find(({ user }) => user === myInfo?._id);
@@ -97,7 +101,16 @@ const ArticleHeader = ({ article, tags, title }: ArticleHeaderProps) => {
 
   return (
     <Flex justify="space-between" css={headerStyle}>
-      <Flex direction="column" gap={20} css={headerLeftItemStyle}>
+      <Flex direction="column" gap={10} css={headerLeftItemStyle}>
+        <Text
+          size={16}
+          color={theme.TEXT300}
+          css={css`
+            cursor: pointer;
+          `}
+          onClick={() => navigate(PATH.CHANNEL(article.channel._id))}>
+          {channelName}
+        </Text>
         <Text size={32} strong={true}>
           {title}
         </Text>

--- a/src/components/organisms/Card/Card.styles.ts
+++ b/src/components/organisms/Card/Card.styles.ts
@@ -21,6 +21,7 @@ export const cardImgStyle = css`
 `;
 
 export const userInfoStyle = css`
+  width: 60%;
   margin: 8px 0 0 8px;
   cursor: pointer;
 `;

--- a/src/components/organisms/Card/Card.tsx
+++ b/src/components/organisms/Card/Card.tsx
@@ -54,6 +54,7 @@ const Card = ({ article, channelVisible = false }: CardProps) => {
             css={css`
               cursor: pointer;
               margin: 8px 12px 0 0;
+              white-space: nowrap;
             `}
             onClick={() => navigate(PATH.CHANNEL(article.channel._id))}>
             {channelName}

--- a/src/components/organisms/Card/Card.tsx
+++ b/src/components/organisms/Card/Card.tsx
@@ -5,7 +5,10 @@ import { css } from "@emotion/react";
 import Flex from "@components/atoms/Flex";
 import Icon from "@components/atoms/Icon";
 import Image from "@components/atoms/Image";
+import Text from "@components/atoms/Text";
 import UserInfo from "@components/molecules/UserInfo";
+
+import { useChannelName } from "@hooks/useChannelName";
 
 import { useThemeStore } from "@stores/theme.store";
 
@@ -21,22 +24,42 @@ import CardFooter from "./CardFooter";
 
 type CardProps = {
   article: Article;
+  channelVisible?: boolean;
 };
 
-const Card = ({ article }: CardProps) => {
+const Card = ({ article, channelVisible = false }: CardProps) => {
   const { theme } = useThemeStore();
   const navigate = useNavigate();
+  const channelName = useChannelName(article.channel._id);
 
   return (
     <Flex css={getCardOuterStyle(theme)} direction="column" gap={4}>
-      <UserInfo
-        imgWidth={24}
-        imageSrc={article.author.image || placeholderUser}
-        username={article.author.fullName}
-        fontSize={14}
-        css={userInfoStyle}
-        onClick={() => navigate(PATH.USER(article.author._id))}
-      />
+      <Flex
+        align="center"
+        justify="space-between"
+        css={css`
+          width: 100%;
+        `}>
+        <UserInfo
+          imgWidth={24}
+          imageSrc={article.author.image || placeholderUser}
+          username={article.author.fullName}
+          fontSize={14}
+          css={userInfoStyle}
+          onClick={() => navigate(PATH.USER(article.author._id))}
+        />
+        {channelVisible && (
+          <Text
+            size={12}
+            css={css`
+              cursor: pointer;
+              margin: 8px 12px 0 0;
+            `}
+            onClick={() => navigate(PATH.CHANNEL(article.channel._id))}>
+            {channelName}
+          </Text>
+        )}
+      </Flex>
 
       {article.image ? (
         <Image

--- a/src/components/organisms/CardList/CardList.tsx
+++ b/src/components/organisms/CardList/CardList.tsx
@@ -9,17 +9,19 @@ import { cardListStyle } from "./CardList.styles";
 
 const CardList = ({
   articles,
-  isFetchingNext
+  isFetchingNext,
+  channelVisible = false
 }: {
   articles?: Article[];
   isFetchingNext?: boolean;
+  channelVisible?: boolean;
 }) => {
   return (
     <div css={cardListStyle}>
       {articles?.map((article) => (
         <Fragment key={article._id}>
           <ErrorBoundary fallback={null}>
-            <Card article={article} />
+            <Card article={article} channelVisible={channelVisible} />
           </ErrorBoundary>
         </Fragment>
       ))}

--- a/src/components/organisms/SearchModal/SearchItem.tsx
+++ b/src/components/organisms/SearchModal/SearchItem.tsx
@@ -6,6 +6,8 @@ import Flex from "@components/atoms/Flex";
 import Text from "@components/atoms/Text";
 import UserInfo from "@components/molecules/UserInfo";
 
+import { useChannelName } from "@hooks/useChannelName";
+
 import { useThemeStore } from "@stores/theme.store";
 
 import {
@@ -26,6 +28,7 @@ const SearchItem = ({
 }) => {
   const theme = useThemeStore((state) => state.theme);
   const navigate = useNavigate();
+  const channelName = useChannelName(article.channel._id);
 
   const { title } = articleTitleDataToArticleContent(article.title);
 
@@ -48,17 +51,22 @@ const SearchItem = ({
           background-color: ${theme.BACKGROUND200};
         }
       `}>
-      <Text
-        size={20}
-        strong={true}
-        css={css`
-          width: 300px;
-          overflow: hidden;
-          white-space: nowrap;
-          text-overflow: ellipsis;
-        `}>
-        {title}
-      </Text>
+      <Flex direction="column">
+        <Text size={12} color={theme.TEXT300}>
+          {channelName}
+        </Text>
+        <Text
+          size={20}
+          strong={true}
+          css={css`
+            width: 300px;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+          `}>
+          {title}
+        </Text>
+      </Flex>
       <UserInfo
         imageSrc={article.author.image || placeholderUser}
         imgWidth={30}

--- a/src/hooks/useChannelName.ts
+++ b/src/hooks/useChannelName.ts
@@ -1,0 +1,6 @@
+import { useChannelsQuery } from "./api/useChannelsQuery";
+
+export const useChannelName = (id: string) => {
+  const { channels } = useChannelsQuery();
+  return channels.find((channel) => channel._id === id)?.name;
+};

--- a/src/pages/ChannelPage/ChannelPageSkeleton.tsx
+++ b/src/pages/ChannelPage/ChannelPageSkeleton.tsx
@@ -1,3 +1,5 @@
+import { css } from "@emotion/react";
+
 import Flex from "@components/atoms/Flex";
 import Text from "@components/atoms/Text";
 import { CardList } from "@components/organisms/CardList";
@@ -19,7 +21,14 @@ const ChannelPageSkeleton = () => {
           채널
         </Text>
       </Flex>
-      <CardList isFetchingNext={true} />
+      <div
+        css={css`
+          box-sizing: border-box;
+          padding: 20px 20px 0 0;
+          width: 100%;
+        `}>
+        <CardList isFetchingNext={true} />
+      </div>
     </Flex>
   );
 };

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -37,7 +37,7 @@ const SearchPage = () => {
           padding: 20px 20px 0 0;
           width: 100%;
         `}>
-        <CardList articles={articles} />
+        <CardList articles={articles} channelVisible={true} />
       </div>
     </Flex>
   );

--- a/src/pages/UserPage/ArticleList.tsx
+++ b/src/pages/UserPage/ArticleList.tsx
@@ -21,7 +21,7 @@ const ArticleList = ({ userId, currentChannel }: ArticleListProps) => {
       css={css`
         width: 100%;
       `}>
-      <CardList articles={articles} />
+      <CardList articles={articles} channelVisible={currentChannel === "all"} />
     </div>
   );
 };

--- a/src/types/apis/etc/SearchAll.ts
+++ b/src/types/apis/etc/SearchAll.ts
@@ -5,6 +5,7 @@ import { User } from "@type/models/User";
 export type ArticleSearchResult = Combine<
   {
     author: string;
+    channel: string;
   },
   Article
 >;


### PR DESCRIPTION
## 📌 이슈 번호
close #202 

## 🚀 구현 내용
- [feat: 한글화된 채널명을 가져오는 훅 추가](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/f4acce1ededc56d12f2a6461e202996c9fb9e322)
- [feat: 아티클 헤더에 채널명 추가](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/816fdc0e4e3da16c63ab640583382c90ecc72899)
- [feat: 카드 컴포넌트에 채널명 보여주는 기능 추가](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/73179950da8552aa36e324647ea28ccfcb2289a7)
- [feat: 검색 페이지의 카드에 채널명 추가](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/536e82c5ab26ebd2c5bf0bc1e7e528a9f7778530)
- [feat: 검색결과 아이템에 채널명 보여주는 기능 추가](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/2590eafd1e8d51b807feaeecea747f30933fbb98)
- [feat: 유저 페이지의 탭이 전체일 때 카드에 채널명 보여주기 추가](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/pull/203/commits/1833c6adc55fef9238d42fb3021e5a35bed0c389)

## 📘 참고 사항
한글화된 채널명을 가져오는 훅 추가했습니다.
모든 api의 채널명을 한글로 변경할 수 없기에 이 훅을 사용하면 될 듯 합니다.

