### PR TITLE
[ 진욱 ] 안읽은 알림 있을 때 아이콘에 표시기능

### DIFF
--- a/src/components/organisms/NotiDropdown/NotiDropdown.styles.ts
+++ b/src/components/organisms/NotiDropdown/NotiDropdown.styles.ts
@@ -38,15 +38,22 @@ export const noNotificationStyle = css`
   flex-grow: 1;
 `;
 
-export const notiDropdownItemStyle = css`
+export const getNotiDropdownItemStyle = (theme: Theme) => css`
   cursor: pointer;
   width: 100%;
   padding: 10px;
   box-sizing: border-box;
   border-bottom: 1px solid var(--border-color);
+  :hover {
+    background-color: ${theme.BACKGROUND200};
+  }
 `;
 
 export const getUserImageStyle = (theme: Theme, seen: boolean) => css`
+  box-sizing: border-box;
   border: 1px solid ${seen ? "var(--border-color)" : theme.PRIMARY};
   border-radius: 50%;
+  :hover {
+    border-width: 3px;
+  }
 `;

--- a/src/components/organisms/NotiDropdown/NotiDropdown.tsx
+++ b/src/components/organisms/NotiDropdown/NotiDropdown.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 import Dropdown from "@components/atoms/Dropdown";
@@ -6,10 +5,11 @@ import Flex from "@components/atoms/Flex";
 import Image from "@components/atoms/Image";
 import Text from "@components/atoms/Text";
 
-import { useNotificationsQuery } from "@hooks/api/useNotificationsQuery";
 import { useNotificationsReadMutation } from "@hooks/api/useNotificationsReadMutation";
 
 import { useThemeStore } from "@stores/theme.store";
+
+import { Notification } from "@type/models/Notification";
 
 import { PATH } from "@constants/index";
 
@@ -26,24 +26,24 @@ import {
   notiDropdownItemStyle,
   readButtonWarpperStyle
 } from "./NotiDropdown.styles";
-import { filterNotifications } from "./filterNotifications";
 
 type NotiDropdownProps = {
+  notifications: Notification[];
   visible: boolean;
   top?: number;
   left?: number;
   onClose: () => void;
 };
 
-const NotiDropdown = ({ visible, onClose, top, left }: NotiDropdownProps) => {
+const NotiDropdown = ({
+  notifications,
+  visible,
+  onClose,
+  top,
+  left
+}: NotiDropdownProps) => {
   const theme = useThemeStore((state) => state.theme);
   const navigate = useNavigate();
-
-  const { notifications: rawNotifications } = useNotificationsQuery();
-  const notifications = useMemo(
-    () => filterNotifications(rawNotifications),
-    [rawNotifications]
-  );
 
   const { mutate: notificationsReadMutate } = useNotificationsReadMutation();
 

--- a/src/components/organisms/NotiDropdown/NotiDropdown.tsx
+++ b/src/components/organisms/NotiDropdown/NotiDropdown.tsx
@@ -18,12 +18,12 @@ import { createdAtToString } from "@utils/createdAtToString";
 import placeholderUser from "@assets/svg/placeholderUser.svg";
 
 import {
+  getNotiDropdownItemStyle,
   getNotiDropdownOuterStyle,
   getReadButtonStyle,
   getUserImageStyle,
   noNotificationStyle,
   notiDropdownInnerStyle,
-  notiDropdownItemStyle,
   readButtonWarpperStyle
 } from "./NotiDropdown.styles";
 
@@ -74,7 +74,7 @@ const NotiDropdown = ({
             key={_id}
             align="center"
             gap={10}
-            css={notiDropdownItemStyle}
+            css={getNotiDropdownItemStyle(theme)}
             onClick={() => {
               onClose();
               post && navigate(PATH.ARTICLE(post));

--- a/src/components/organisms/Sidebar/NotificationItem.tsx
+++ b/src/components/organisms/Sidebar/NotificationItem.tsx
@@ -75,12 +75,13 @@ const NotificationItem = ({
       {notifications.length > 0 && (
         <div
           css={css`
+            border: 2px solid ${theme.BACKGROUND100};
             border-radius: 50%;
             padding: 5px;
             background-color: ${theme.PRIMARY};
             position: absolute;
-            top: 11px;
-            left: 28px;
+            top: 10px;
+            left: 27px;
           `}
         />
       )}

--- a/src/components/organisms/Sidebar/NotificationItem.tsx
+++ b/src/components/organisms/Sidebar/NotificationItem.tsx
@@ -1,0 +1,91 @@
+import { useCallback, useRef, useState } from "react";
+
+import { css } from "@emotion/react";
+
+import IconText from "@components/molecules/IconText";
+
+import { useNotificationsQuery } from "@hooks/api/useNotificationsQuery";
+import { useSidebarContext } from "@hooks/contexts/useSidebarContext";
+
+import { Theme } from "@constants/theme";
+
+import { Alert } from "@assets/svg";
+
+import { NotiDropdown } from "../NotiDropdown";
+import { getSidebarIconText } from "./Sidebar.styles";
+
+type NotificationItemProps = {
+  theme: Theme;
+  channelIconSize: number;
+  channelTextSize: number;
+  channelColor: string;
+};
+
+const NotificationItem = ({
+  theme,
+  channelIconSize,
+  channelTextSize,
+  channelColor
+}: NotificationItemProps) => {
+  const { setSidebarAppear } = useSidebarContext();
+  const [isNotiDropdownOpen, setIsNotiDropdownOpen] = useState(false);
+  const notificationRef = useRef<HTMLDivElement | null>(null);
+  const { notifications } = useNotificationsQuery();
+
+  const getNotiDropdownPos = useCallback(() => {
+    if (!notificationRef.current) {
+      return { top: 0, left: 0 };
+    }
+
+    const { top, left } = notificationRef.current.getBoundingClientRect();
+
+    return { top, left };
+  }, []);
+
+  return (
+    <div
+      ref={notificationRef}
+      css={css`
+        position: relative;
+      `}>
+      <IconText
+        iconValue={{
+          Svg: Alert,
+          size: channelIconSize,
+          fill: channelColor
+        }}
+        textValue={{
+          children: "알림",
+          size: channelTextSize,
+          color: channelColor
+        }}
+        css={getSidebarIconText(theme)}
+        onClick={() => setIsNotiDropdownOpen(true)}
+      />
+      <NotiDropdown
+        notifications={notifications}
+        top={getNotiDropdownPos().top}
+        left={getNotiDropdownPos().left + 100}
+        visible={isNotiDropdownOpen}
+        onClose={() => {
+          setIsNotiDropdownOpen(false);
+          setSidebarAppear(false);
+        }}
+      />
+      {notifications.length > 0 && (
+        <div
+          css={css`
+            border-radius: 50%;
+            padding: 5px;
+            background-color: ${theme.PRIMARY};
+            position: absolute;
+            top: 11px;
+            left: 28px;
+          `}
+        />
+      )}
+    </div>
+  );
+};
+
+export default NotificationItem;

--- a/src/components/organisms/Sidebar/SidebarMain.tsx
+++ b/src/components/organisms/Sidebar/SidebarMain.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useState } from "react";
 
 import Text from "@components/atoms/Text";
 import IconText from "@components/molecules/IconText";
@@ -8,11 +8,11 @@ import { useSidebarContext } from "@hooks/contexts/useSidebarContext";
 
 import { Theme } from "@constants/theme";
 
-import { Alert, Home, Search } from "@assets/svg";
+import { Home, Search } from "@assets/svg";
 import placeholderUser from "@assets/svg/placeholderUser.svg";
 
-import { NotiDropdown } from "../NotiDropdown";
 import { SearchModal } from "../SearchModal";
+import NotificationItem from "./NotificationItem";
 import {
   getSelectedSidebarIconText,
   getSelectedUserInfoStyle,
@@ -43,19 +43,7 @@ const SidebarMain = ({
 }: SidebarMainProps) => {
   const channelColor = theme.TEXT300;
   const { setSidebarAppear } = useSidebarContext();
-  const [isNotiDropdownOpen, setIsNotiDropdownOpen] = useState(false);
   const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
-  const notificationRef = useRef<HTMLDivElement | null>(null);
-
-  const getNotiDropdownPos = useCallback(() => {
-    if (!notificationRef.current) {
-      return { top: 0, left: 0 };
-    }
-
-    const { top, left } = notificationRef.current.getBoundingClientRect();
-
-    return { top, left };
-  }, []);
 
   return (
     <>
@@ -110,32 +98,11 @@ const SidebarMain = ({
         />
       )}
       {isLoggedIn && (
-        <div ref={notificationRef}>
-          <IconText
-            iconValue={{
-              Svg: Alert,
-              size: channelIconSize,
-              fill: channelColor
-            }}
-            textValue={{
-              children: "알림",
-              size: channelTextSize,
-              color: channelColor
-            }}
-            css={getSidebarIconText(theme)}
-            onClick={() => setIsNotiDropdownOpen(true)}
-          />
-        </div>
-      )}
-      {isLoggedIn && (
-        <NotiDropdown
-          top={getNotiDropdownPos().top}
-          left={getNotiDropdownPos().left + 100}
-          visible={isNotiDropdownOpen}
-          onClose={() => {
-            setIsNotiDropdownOpen(false);
-            setSidebarAppear(false);
-          }}
+        <NotificationItem
+          theme={theme}
+          channelIconSize={channelIconSize}
+          channelTextSize={channelTextSize}
+          channelColor={channelColor}
         />
       )}
       <SearchModal

--- a/src/hooks/api/useNotificationsQuery.ts
+++ b/src/hooks/api/useNotificationsQuery.ts
@@ -2,11 +2,20 @@ import { useQuery } from "@tanstack/react-query";
 
 import { getNotifications } from "@apis/notification/getNotifications";
 
+import { filterNotifications } from "@components/organisms/NotiDropdown/filterNotifications";
+
 export const useNotificationsQuery = () => {
-  const { data } = useQuery(["notifications"], getNotifications, {
-    staleTime: 10000,
-    suspense: true
-  });
+  const { data } = useQuery(
+    ["notifications"],
+    async () => {
+      const rawNotifications = await getNotifications();
+      return filterNotifications(rawNotifications);
+    },
+    {
+      staleTime: 10000,
+      suspense: true
+    }
+  );
 
   return { notifications: data! };
 };


### PR DESCRIPTION
## 📌 이슈 번호
close #224 

## 🚀 구현 내용
- [refactor: 알림 드롭다운이 알림 데이터를 전달받게 수정](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/cda57bbd7d99b2bae4385519d0fccaa4a8df5c67)
- [feat: 알림 쿼리에 알림 필터링 로직 추가](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/edfa815a53cfe41eb57d8443b46cf8a8fa5173eb)
- [refactor: 사이드바 알림버튼 전체를 컴포넌트로 분리](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/32ddc3262600f28e73879a6065c47238206ed38c)
- [design: 알림 툴팁에 border 추가](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/3d1d01b8e450d20979a788f17b3bb9ddc7d12fac)

