### PR TITLE
[ 혜수 ] 태그 있을때와 없을때 높이 같도록 수정

### DIFF
--- a/src/components/organisms/ArticleWrite/ArticleWriteTag.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWriteTag.tsx
@@ -57,24 +57,29 @@ const ArticleTag = ({ stateChange, state, width }: ArticleTagProps) => {
           border: none;
         `}
       />
-      <Flex
-        gap={10}
+      <div
         css={css`
-          padding: 10px;
+          height: 44px;
         `}>
-        {tags.map((tag, index) => {
-          return (
-            <Tag
-              key={index}
-              size={16}
-              name={tag}
-              onClick={() => {
-                removeFromSet(tag);
-              }}
-            />
-          );
-        })}
-      </Flex>
+        <Flex
+          gap={10}
+          css={css`
+            padding: 10px;
+          `}>
+          {tags.map((tag, index) => {
+            return (
+              <Tag
+                key={index}
+                size={16}
+                name={tag}
+                onClick={() => {
+                  removeFromSet(tag);
+                }}
+              />
+            );
+          })}
+        </Flex>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## 📌 이슈 번호
close #241 
## 🚀 구현 내용
- 태그 있을 때랑 없을 때 높이 같게 수정 -> div로 고정 높이 만들어줌
## 📘 참고 사항
<img width="1792" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/assets/67812466/9a4e12dd-241a-479c-9e8c-7c4f74b8ae1d">
<img width="1792" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/assets/67812466/e8cd487d-6bd2-4c5f-8ff6-810d6770d384">

## ❓ 궁금한 내용

## ETC
