### PR TITLE
[ 진욱 ] 댓글 작성 시 폼 높이 늘어나게 변경 

### DIFF
--- a/src/components/molecules/CommentForm.tsx
+++ b/src/components/molecules/CommentForm.tsx
@@ -60,6 +60,17 @@ const CommentForm = ({ width, article }: CommentFormProps) => {
     );
   };
 
+  const [editorHeight, setEditorHeight] = useState(100);
+  const editorInputEl = document.querySelector<HTMLDivElement>(
+    ".w-md-editor-text-input"
+  );
+  const editorPreviewEl = document.querySelector<HTMLDivElement>(
+    ".w-md-editor-preview"
+  );
+  const editorToolbarEl = document.querySelector<HTMLDivElement>(
+    ".w-md-editor-toolbar"
+  );
+
   return (
     <Flex
       justify="center"
@@ -97,10 +108,18 @@ const CommentForm = ({ width, article }: CommentFormProps) => {
           data-color-mode={theme.type === "LIGHT" ? "light" : "dark"}
           preview="live"
           extraCommands={[codeEdit, codePreview, codeLive]}
-          height={100}
+          height={editorHeight}
           highlightEnable={false}
           value={comment}
-          onChange={(str) => setComment(str || "")}
+          onChange={(str) => {
+            setComment(str || "");
+            setEditorHeight(
+              Math.max(
+                editorInputEl?.scrollHeight || editorHeight,
+                editorPreviewEl?.scrollHeight || editorHeight
+              ) + (editorToolbarEl?.offsetHeight || 0)
+            );
+          }}
           css={getEditorStyle(theme)}
         />
         <Button


### PR DESCRIPTION
## 📌 이슈 번호
close #246 

## 🚀 구현 내용

https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/assets/81508534/986409b0-a379-4fd7-b11a-b7c602a41cfd

[feat: 댓글폼에 입력 시 폼 높이 늘어나는 기능 추가](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/b54d9c61bc28a095c518d7fd033ac0d35fc21462)

## 📘 참고 사항
마우스로 높이 조절도 됩니다.