### PR TITLE
[ 진욱 ] 카드 컴포넌트의 빈부분을 클릭해도 게시글로 이동할 수 있는 기능 추가

### DIFF
--- a/src/components/organisms/Card/Card.styles.ts
+++ b/src/components/organisms/Card/Card.styles.ts
@@ -8,6 +8,7 @@ export const getCardOuterStyle = (theme: Theme) => css`
   box-shadow: ${theme.SHADOW};
   border-radius: 8px;
   background-color: ${theme.BACKGROUND200};
+  cursor: pointer;
   :hover {
     transform: scale(1.02);
     transition: transform 0.3s ease;

--- a/src/components/organisms/Card/Card.tsx
+++ b/src/components/organisms/Card/Card.tsx
@@ -32,8 +32,17 @@ const Card = ({ article, channelVisible = false }: CardProps) => {
   const navigate = useNavigate();
   const channelName = useChannelName(article.channel._id);
 
+  const handleCardClick = (e: React.MouseEvent, path: string) => {
+    e.stopPropagation();
+    navigate(path);
+  };
+
   return (
-    <Flex css={getCardOuterStyle(theme)} direction="column" gap={4}>
+    <Flex
+      css={getCardOuterStyle(theme)}
+      direction="column"
+      gap={4}
+      onClick={(e) => handleCardClick(e, PATH.ARTICLE(article._id))}>
       <Flex
         align="center"
         justify="space-between"
@@ -46,7 +55,7 @@ const Card = ({ article, channelVisible = false }: CardProps) => {
           username={article.author.fullName}
           fontSize={14}
           css={userInfoStyle}
-          onClick={() => navigate(PATH.USER(article.author._id))}
+          onClick={(e) => handleCardClick(e, PATH.USER(article.author._id))}
         />
         {channelVisible && (
           <Text
@@ -56,7 +65,9 @@ const Card = ({ article, channelVisible = false }: CardProps) => {
               margin: 8px 12px 0 0;
               white-space: nowrap;
             `}
-            onClick={() => navigate(PATH.CHANNEL(article.channel._id))}>
+            onClick={(e) =>
+              handleCardClick(e, PATH.CHANNEL(article.channel._id))
+            }>
             {channelName}
           </Text>
         )}
@@ -68,7 +79,7 @@ const Card = ({ article, channelVisible = false }: CardProps) => {
           alt="contentImg"
           mode="cover"
           css={cardImgStyle}
-          onClick={() => navigate(PATH.ARTICLE(article._id))}
+          onClick={(e) => handleCardClick(e, PATH.ARTICLE(article._id))}
         />
       ) : (
         <Flex
@@ -79,7 +90,7 @@ const Card = ({ article, channelVisible = false }: CardProps) => {
             aspect-ratio: 16 / 10;
             cursor: pointer;
           `}
-          onClick={() => navigate(PATH.ARTICLE(article._id))}>
+          onClick={(e) => handleCardClick(e, PATH.ARTICLE(article._id))}>
           <Icon Svg={NoImage} size={70} fill={theme.BACKGROUND300} />
         </Flex>
       )}

--- a/src/components/organisms/Card/CardFooter.tsx
+++ b/src/components/organisms/Card/CardFooter.tsx
@@ -1,5 +1,3 @@
-import { useNavigate } from "react-router-dom";
-
 import { css } from "@emotion/react";
 import markdownToTxt from "markdown-to-txt";
 
@@ -14,8 +12,6 @@ import {
   Article,
   articleTitleDataToArticleContent
 } from "@type/models/Article";
-
-import { PATH } from "@constants/index";
 
 import { createdAtToString } from "@utils/createdAtToString";
 
@@ -35,19 +31,13 @@ type CardFooterProps = {
 
 const CardFooter = ({ article }: CardFooterProps) => {
   const { theme } = useThemeStore();
-  const navigate = useNavigate();
-
   const { title, content, tags } = articleTitleDataToArticleContent(
     article.title
   );
 
   return (
     <Flex direction="column" gap={8} css={cardFoorterOuterStyle}>
-      <Flex
-        direction="column"
-        gap={8}
-        css={cardDescriptionStyle}
-        onClick={() => navigate(PATH.ARTICLE(article._id))}>
+      <Flex direction="column" gap={8} css={cardDescriptionStyle}>
         <Text size={16} strong={true} css={titleStyle}>
           {title}
         </Text>


### PR DESCRIPTION
## 📌 이슈 번호
close #248 

## 🚀 구현 내용
[feat: 카드 컴포넌트의 빈부분을 클릭해도 게시글로 이동할 수 있는 기능 추가](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/768129bfb7bf948bfbda281cb257433e9cb0c9f8)

