### PR TITLE
[ 진욱 ] 게시글 삭제 시 에러 수정

### DIFF
--- a/src/components/organisms/ArticleHeader/ArticleHeader.tsx
+++ b/src/components/organisms/ArticleHeader/ArticleHeader.tsx
@@ -80,11 +80,8 @@ const ArticleHeader = ({ article, tags, title }: ArticleHeaderProps) => {
 
   const handleDeleteArticle = () => {
     if (isMyArticle) {
-      articleDeleteMutate(article._id, {
-        onSuccess: (article) => {
-          navigate(PATH.CHANNEL(article.channel), { replace: true });
-        }
-      });
+      navigate(PATH.CHANNEL(article.channel._id), { replace: true });
+      articleDeleteMutate(article._id);
     }
   };
 

--- a/src/hooks/api/useArticleCreateMutation.ts
+++ b/src/hooks/api/useArticleCreateMutation.ts
@@ -9,6 +9,7 @@ export const useArticleCreateMutation = () => {
     mutationFn: createArticle,
     onSuccess: (article) =>
       Promise.all([
+        queryClient.resetQueries(["articles", article.author._id]),
         queryClient.resetQueries(["articles", article.channel._id]),
         queryClient.invalidateQueries(["main-articles"]),
         queryClient.invalidateQueries(["user-by-token"])

--- a/src/hooks/api/useArticleDeleteMutation.ts
+++ b/src/hooks/api/useArticleDeleteMutation.ts
@@ -9,6 +9,7 @@ export const useArticleDeleteMutation = () => {
     mutationFn: deleteArticle,
     onSuccess: (article) =>
       Promise.all([
+        queryClient.resetQueries(["articles", article.author]),
         queryClient.resetQueries(["articles", article.channel]),
         queryClient.invalidateQueries(["article", article._id]),
         queryClient.invalidateQueries(["main-articles"]),


### PR DESCRIPTION
## 📌 이슈 번호
close #250 

## 🚀 구현 내용
[feat: 아티클 생성, 삭제 뮤테이션이 유저의 게시글들도 invalidate 하게 변경](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/a6bc5e75b09733b16dcba17d5e972f6f907193e1)
[fix: onSuccess에서 navigate하던 것을 mutate하기 전으로 변경](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/6dd6a884a60e586256eed077541f89bbd2465885)

## 📘 참고 사항
기존에 에러가 나면서 홈페이지로 리디렉션 되는 것을 수정했습니다.
