### PR TITLE
[ 진욱 ] 404 페이지 로고 수정

### DIFF
--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -41,7 +41,12 @@ const ErrorPage = () => {
           gap: 20px;
         `}>
         <IconText
-          iconValue={{ Svg: Logo, size: 80, fill: theme.TEXT300 }}
+          css={css`
+            gap: 10px;
+            cursor: pointer;
+          `}
+          onClick={() => navigate(PATH.HOME)}
+          iconValue={{ Svg: Logo, size: 64, fill: theme.TEXT300 }}
           textValue={{ children: "괴발개발", size: 48, color: theme.TEXT300 }}
         />
         <Flex
@@ -51,6 +56,7 @@ const ErrorPage = () => {
           gap={10}
           css={css`
             box-sizing: border-box;
+            box-shadow: ${theme.SHADOW};
             padding: 24px;
             width: 320px;
             height: 400px;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -93,12 +93,12 @@ const LoginPage = () => {
           width: 320px;
           height: 428px;
           gap: 20px;
-          cursor: pointer;
         `}>
         <Flex>
           <IconText
             css={css`
               gap: 10px;
+              cursor: pointer;
             `}
             onClick={handleMoveHome}
             iconValue={{ Svg: Logo, size: 64, fill: theme.TEXT300 }}


### PR DESCRIPTION
## 📌 이슈 번호
close #252 

## 🚀 구현 내용
<img width="496" alt="스크린샷 2023-10-10 오후 3 41 16" src="https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/assets/81508534/a0f54b11-faab-45b6-a392-aa433b932cfc">

[fix: 에러 페이지 로고 수정](https://github.com/prgrms-fe-devcourse/FEDC4_SCRAWL_Yohan/commit/9c1f590f96775742afcb187bb83aeda6d44bc522)

## 참고 사항
로고 호버 시 포인터 추가
로고 클릭 시 홈페이지 이동
박스 쉐도우 추가