### PR TITLE
[ 동현 ] 글 수정 페이지의 썸네일 모달에서 기존 썸네일 가져오는게 안됨

### DIFF
--- a/src/components/organisms/ArticleWrite/ArticleEdit.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleEdit.tsx
@@ -35,6 +35,7 @@ const ArticleEdit = () => {
   const { dispatchError } = useError();
   const { isLoggedIn } = useLoggedIn();
   const { article } = useArticleQuery(location.pathname.split("/")[2]);
+  console.log(article);
   const articleId = article.channel._id;
   const {
     title: preTitle,
@@ -91,6 +92,7 @@ const ArticleEdit = () => {
         css={getEditorStyle(theme)}
       />
       <ArticleWriteButtons
+        image={article.image}
         theme={theme}
         navigatePage={navigatePage}
         totalContent={{ title, channelId, content, tags }}

--- a/src/components/organisms/ArticleWrite/ArticleWriteButtons.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWriteButtons.tsx
@@ -23,6 +23,7 @@ type totalContentType = {
 };
 
 type ArticleWriteButtonsProps = {
+  image?: string;
   theme: Theme;
   navigatePage: (page: string) => void;
   totalContent: totalContentType;
@@ -31,6 +32,7 @@ type ArticleWriteButtonsProps = {
 };
 
 const ArticleWriteButtons = ({
+  image,
   theme,
   navigatePage,
   totalContent,
@@ -46,6 +48,10 @@ const ArticleWriteButtons = ({
 
   const handleToggleModal = () => {
     setIsOpen((state) => !state);
+    if (image) {
+      setImageUrl(image);
+    }
+    // purpose가 update라면, 서버로 부터 article정보를 가져와서, setImageUrl하기
   };
 
   const handleChangeImageFile: ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -114,7 +120,6 @@ const ArticleWriteButtons = ({
             <ThumnailChooseModal
               onImageChange={handleChangeImageFile}
               onButtonClick={handleCreateArticle}
-              imageFile={imageFile}
               imageUrl={imageUrl}
             />
           }

--- a/src/components/organisms/ArticleWrite/ThumnailChooseModal.tsx
+++ b/src/components/organisms/ArticleWrite/ThumnailChooseModal.tsx
@@ -12,14 +12,12 @@ import { useThemeStore } from "@stores/theme.store";
 import noImage from "@assets/svg/noImage.svg";
 
 type ThumnailChooseModalProps = {
-  imageFile: File | null;
   imageUrl: string;
   onImageChange: ChangeEventHandler<HTMLInputElement>;
   onButtonClick: MouseEventHandler<HTMLButtonElement>;
 };
 
 const ThumnailChooseModal = ({
-  imageFile,
   imageUrl,
   onImageChange,
   onButtonClick
@@ -65,7 +63,7 @@ const ThumnailChooseModal = ({
         />
       </Flex>
       <Button onClick={onButtonClick}>
-        {imageFile ? "현재" : "기본"} 썸네일로 글 생성
+        {imageUrl ? "현재" : "기본"} 썸네일로 글 생성
       </Button>
     </Flex>
   );


### PR DESCRIPTION
## 📌 이슈 번호
close #254 
## 🚀 구현 내용
- 글 수정 시, 기존 썸네일 가져오기
## 📘 참고 사항
"썸네일 업로드 기본이미지 오류(업데이트 문제)" 이슈 같은 경우,
현재 이슈인 "글 수정 페이지의 썸네일 모달에서 기존 썸네일 가져오는게 안됨" 을 해결하면서
구현의 필요성이 사라졌습니다.(기본 썸네일을 애초에 선택 할 수 없게 됨)
그러나, 기본 썸네일로 수정하는 기능을 추가하길 원하시단면 빠른 시일내에 추가하겠습니다.
## ❓ 궁금한 내용 

## ETC
