### PR TITLE
[ 혜수 ] 채널탭에서 새글쓰기 했을 때 눌렀던 해당 탭의 채널이 선택되어있도록 변경, 작성하던 글 저장기능 추가

### DIFF
--- a/src/components/organisms/ArticleWrite/ArticleChannelSelect.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleChannelSelect.tsx
@@ -44,7 +44,7 @@ const ArticleChannelSelect = ({
   const channelList = [...useChannelsQuery().channels];
   const Mychannel = channelList.filter((x) => x._id === state);
   const [channelIdentify, setChannelIdentify] = useState(
-    state ? Mychannel[0].name : "채널 선택"
+    Mychannel.length ? Mychannel[0].name : "채널 선택"
   );
   const { theme } = useThemeStore();
   const [isOpen, setIsOpen] = useDetectClose(dropdownRef, false);

--- a/src/components/organisms/ArticleWrite/ArticleWrite.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWrite.tsx
@@ -16,6 +16,7 @@ import { useLoggedIn } from "@hooks/useLoggedIn";
 
 import { getEditorStyle } from "@styles/getEditorStyles";
 
+import { useChannel } from "@stores/channel.store";
 import { useThemeStore } from "@stores/theme.store";
 
 import { AuthError } from "@utils/AuthError";
@@ -34,7 +35,7 @@ const ArticleWrite = () => {
   const [tags, setTags] = useState<string[]>([]);
   const [content, setContent] = useState("");
   const { theme } = useThemeStore();
-
+  const { channel } = useChannel();
   if (!isLoggedIn) dispatchError(new AuthError("로그인이 필요합니다."));
 
   const navigatePage = (page: string) => {
@@ -55,7 +56,10 @@ const ArticleWrite = () => {
       <Helmet key={location.pathname}>
         <title>새 글 작성</title>
       </Helmet>
-      <ArticleChannelSelect stateChange={(value) => setChannelId(value)} />
+      <ArticleChannelSelect
+        stateChange={(value) => setChannelId(value)}
+        state={channel}
+      />
       <ArticleWriteTitle
         stateChange={(value) => setTitle(value)}
         width="100%"

--- a/src/components/organisms/ArticleWrite/ArticleWriteTag.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWriteTag.tsx
@@ -14,10 +14,18 @@ interface ArticleTagProps {
   stateChange: (value: string[]) => void;
   state?: string[];
   width: string;
+  savedTags?: string[];
 }
-const ArticleTag = ({ stateChange, state, width }: ArticleTagProps) => {
+const ArticleTag = ({
+  stateChange,
+  state,
+  width,
+  savedTags
+}: ArticleTagProps) => {
   const [inputValue, setInputValue] = useState("");
-  const [tags, setTags] = useState<string[]>(state ? [...state] : []);
+  const [tags, setTags] = useState<string[]>(
+    state ? [...state] : savedTags ? savedTags : []
+  );
   const { theme } = useThemeStore();
   const { currentWidth } = useViewportStore();
 

--- a/src/components/organisms/ArticleWrite/ArticleWriteTitle.tsx
+++ b/src/components/organisms/ArticleWrite/ArticleWriteTitle.tsx
@@ -10,9 +10,17 @@ interface ArticleTagProps {
   stateChange: (value: string) => void;
   state?: string;
   width: string;
+  savedTitle?: string;
 }
-const ArticleTitle = ({ stateChange, state, width }: ArticleTagProps) => {
-  const [inputValue, setInputValue] = useState(state ? state : "");
+const ArticleTitle = ({
+  stateChange,
+  state,
+  width,
+  savedTitle
+}: ArticleTagProps) => {
+  const [inputValue, setInputValue] = useState(
+    state ? state : savedTitle ? savedTitle : ""
+  );
   const { theme } = useThemeStore();
   useEffect(() => {
     stateChange(inputValue);

--- a/src/components/templates/PageTemplate/PageTemplate.tsx
+++ b/src/components/templates/PageTemplate/PageTemplate.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 
 import { css } from "@emotion/react";
 
@@ -14,6 +14,7 @@ import {
 
 import { useSidebarContext } from "@hooks/contexts/useSidebarContext";
 
+import { useChannel } from "@stores/channel.store";
 import { useViewportStore } from "@stores/resize.store";
 
 import SidebarProvider from "@contexts/sidebar.context";
@@ -22,7 +23,16 @@ const PageTemplate = () => {
   const [scrollPosition, setScrollPosition] = useState(0);
   const [resizeWidth, setResizeWidth] = useState(window.innerWidth);
   const { setWidth } = useViewportStore();
+  const { channel, setChannel } = useChannel();
+  const location = useLocation().pathname.split("/");
 
+  useEffect(() => {
+    if (channel !== location[2]) {
+      if (location[1] !== "create" && location[3] !== "edit") {
+        setChannel(location[2]);
+      }
+    }
+  });
   const handleScroll = useCallback(() => {
     setScrollPosition(window.scrollY);
   }, []);

--- a/src/stores/channel.store.ts
+++ b/src/stores/channel.store.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+type ChannelState = {
+  channel: string | undefined;
+  setChannel: (value: string | undefined) => void;
+};
+
+export const useChannel = create<ChannelState>((set) => ({
+  channel: undefined,
+  setChannel: (value) => set(() => ({ channel: value }))
+}));

--- a/src/stores/create.store.ts
+++ b/src/stores/create.store.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+type CreateState = {
+  create: { title: string; tags: string[]; content: string };
+  setCreate: (value: {
+    title: string;
+    tags: string[];
+    content: string;
+  }) => void;
+};
+
+export const useCreatStore = create(
+  persist<CreateState>(
+    (set) => ({
+      create: { title: "", tags: [], content: "" },
+      setCreate: (value) => set({ create: value })
+    }),
+    {
+      name: "create",
+      storage: createJSONStorage(() => sessionStorage)
+    }
+  )
+);

--- a/src/stores/edit.store.ts
+++ b/src/stores/edit.store.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+type EditState = {
+  edit: { title: string; tags: string[]; content: string };
+  setEdit: (value: {
+    article_id: string;
+    title: string;
+    tags: string[];
+    content: string;
+  }) => void;
+};
+
+export const useEditStore = create(
+  persist<EditState>(
+    (set) => ({
+      edit: { article_id: "", title: "", tags: [], content: "" },
+      setEdit: (value) => set({ edit: value })
+    }),
+    {
+      name: "edit",
+      storage: createJSONStorage(() => sessionStorage)
+    }
+  )
+);


### PR DESCRIPTION
## 📌 이슈 번호
close #245  
close #259
## 🚀 구현 내용
- #245 
- #259
## 📘 참고 사항
- 글쓰기 전에 있던 채널을 알기위해 전역스토어 만들어서 사용했습니다.
- 글 저장기능도 sessionStoreage 사용을 위해 전역 스토어 만들어 사용했습니다.
## ❓ 궁금한 내용
- 글 수정시 저장되는 기능도 추가했는데 다른 수정페이지를 들어가지않는 한 수정했던 글이 유지되는데 불편한지 궁금합니다.
## ETC
